### PR TITLE
Bump curve25519-dalek version and merge upstream changes

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -71,18 +71,18 @@ jobs:
         args: --features "serde"
 
   msrv:
-    name: Current MSRV is 1.54
+    name: Current MSRV is 1.41
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
     - uses: actions-rs/toolchain@v1
       with:
         profile: minimal
-        toolchain: 1.54
+        toolchain: 1.41
         override: true
     - uses: actions-rs/cargo@v1
       with:
-        command: test
+        command: build
 
   bench:
     name: Check that benchmarks compile

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -71,14 +71,14 @@ jobs:
         args: --features "serde"
 
   msrv:
-    name: Current MSRV is 1.54
+    name: Current MSRV is 1.41
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
     - uses: actions-rs/toolchain@v1
       with:
         profile: minimal
-        toolchain: 1.54
+        toolchain: 1.41
         override: true
     - uses: actions-rs/cargo@v1
       with:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [ '*' ]
   pull_request:
-    branches: [ main, develop ]
+    branches: [ main, develop, release ]
 
 env:
   CARGO_TERM_COLOR: always

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,0 +1,101 @@
+name: Rust
+
+on:
+  push:
+    branches: [ '*' ]
+  pull_request:
+    branches: [ main, develop ]
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  test-u32:
+    name: Test u32 backend
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions-rs/toolchain@v1
+      with:
+        profile: minimal
+        toolchain: stable
+        override: true
+    - uses: actions-rs/cargo@v1
+      with:
+        command: test
+        args: --no-default-features --features "std u32_backend"
+
+  test-u64:
+    name: Test u64 backend
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions-rs/toolchain@v1
+      with:
+        profile: minimal
+        toolchain: stable
+        override: true
+    - uses: actions-rs/cargo@v1
+      with:
+        command: test
+        args: --no-default-features --features "std u64_backend"
+
+  nightly:
+    name: Test nightly compiler
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions-rs/toolchain@v1
+      with:
+        profile: minimal
+        toolchain: nightly
+        override: true
+    - uses: actions-rs/cargo@v1
+      with:
+        command: test
+        args: --features "nightly"
+
+  test-defaults-serde:
+    name: Test default feature selection and serde
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions-rs/toolchain@v1
+      with:
+        profile: minimal
+        toolchain: stable
+        override: true
+    - uses: actions-rs/cargo@v1
+      with:
+        command: test
+        args: --features "serde"
+
+  msrv:
+    name: Current MSRV is 1.54
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions-rs/toolchain@v1
+      with:
+        profile: minimal
+        toolchain: 1.54
+        override: true
+    - uses: actions-rs/cargo@v1
+      with:
+        command: test
+
+  bench:
+    name: Check that benchmarks compile
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions-rs/toolchain@v1
+      with:
+        profile: minimal
+        toolchain: stable
+        override: true
+    - uses: actions-rs/cargo@v1
+      with:
+        command: bench
+        # This filter selects no benchmarks, so we don't run any, only build them.
+        args: "DONTRUNBENCHMARKS"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,24 @@
 
 Entries are listed in reverse chronological order.
 
+# 1.x Series
+
+## 1.2
+
+* Add module documentation for using the bytes-oriented `x25519()` API.
+* Add implementation of `zeroize::Zeroize` for `PublicKey`.
+* Move unittests to a separate directory.
+* Add cargo feature flags `"fiat_u32_backend"` and `"fiat_u64_backend"` for
+  activating the Fiat crypto field element implementations.
+* Fix issue with removed `feature(external_doc)` on nightly compilers.
+* Pin `zeroize` to version 1.3 to support a wider range of MSRVs.
+* Add CI via Github actions.
+* Fix breakage in the serde unittests.
+* MSRV is now 1.41 for production and 1.48 for development.
+* Add an optional check to `SharedSecret` for contibutory behaviour.
+* Add implementation of `ReusableSecret` keys which are non-ephemeral, but which
+  cannot be serialised to discourage long-term use.
+
 ## 1.1.1
 
 * Fix a typo in the README.
@@ -22,6 +40,8 @@ Entries are listed in reverse chronological order.
   arrays, complementing the existing `as_bytes` methods returning references.
 * Remove mention of deprecated `rand_os` crate from examples.
 * Clarify `EphemeralSecret`/`StaticSecret` distinction in documentation.
+
+# Pre-1.0.0
 
 ## 0.6.0
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,4 +60,4 @@ fiat_u64_backend = ["curve25519-dalek/fiat_u64_backend"]
 fiat_u32_backend = ["curve25519-dalek/fiat_u32_backend"]
 
 [patch.crates-io]
-curve25519-dalek = { git = "https://github.com/remoun/curve25519-dalek.git", rev = "77391036a6e43f3c9a2d8b937e621dcfe9d95d8c" }
+curve25519-dalek = { git = "https://github.com/mobilecoinfoundation/curve25519-dalek.git", rev = "8791722e0273762552c9a056eaccb7df6baf44d7" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ travis-ci = { repository = "dalek-cryptography/x25519-dalek", branch = "master"}
 features = ["nightly", "reusable_secrets", "serde"]
 
 [dependencies]
-curve25519-dalek = { version = "4.0.0-pre.1", default-features = false }
+curve25519-dalek = { version = "4.0.0-pre.2", default-features = false }
 rand_core = { version = "0.6", default-features = false }
 # `serde` is renamed to `our_serde` in order to avoid a name collision between
 # importing the serde dependency and enabling the curve25519-dalek/serde feature
@@ -58,3 +58,6 @@ u64_backend = ["curve25519-dalek/u64_backend"]
 u32_backend = ["curve25519-dalek/u32_backend"]
 fiat_u64_backend = ["curve25519-dalek/fiat_u64_backend"]
 fiat_u32_backend = ["curve25519-dalek/fiat_u32_backend"]
+
+[patch.crates-io]
+curve25519-dalek = { git = "https://github.com/remoun/curve25519-dalek.git", rev = "77391036a6e43f3c9a2d8b937e621dcfe9d95d8c" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,7 @@ rand_core = { version = "0.5", default-features = false }
 # `serde` is renamed to `our_serde` in order to avoid a name collision between
 # importing the serde dependency and enabling the curve25519-dalek/serde feature
 our_serde = { package = "serde", version = "1", default-features = false, optional = true, features = ["derive"] }
-zeroize = { version = "1", default-features = false, features = ["zeroize_derive"] }
+zeroize = { version = "=1.3", default-features = false, features = ["zeroize_derive"] }
 
 [dev-dependencies]
 bincode = "1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ travis-ci = { repository = "dalek-cryptography/x25519-dalek", branch = "master"}
 
 [package.metadata.docs.rs]
 #rustdoc-args = ["--html-in-header", ".cargo/registry/src/github.com-1ecc6299db9ec823/curve25519-dalek-1.0.1/docs/assets/rustdoc-include-katex-header.html"]
-features = ["nightly"]
+features = ["nightly", "reusable_secrets", "serde"]
 
 [dependencies]
 curve25519-dalek = { version = "3", default-features = false }
@@ -53,5 +53,6 @@ default = ["std", "u64_backend"]
 serde = ["our_serde", "curve25519-dalek/serde"]
 std = ["curve25519-dalek/std"]
 nightly = ["curve25519-dalek/nightly"]
+reusable_secrets = []
 u64_backend = ["curve25519-dalek/u64_backend"]
 u32_backend = ["curve25519-dalek/u32_backend"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 # - update html_root_url
 # - update CHANGELOG
 # - if any changes were made to README.md, mirror them in src/lib.rs docs
-version = "1.1.1"
+version = "1.2.0"
 authors = [
     "Isis Lovecruft <isis@patternsinthevoid.net>",
     "DebugSteven <debugsteven@gmail.com>",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2018"
 # - update version in README.md
 # - update html_root_url
 # - update CHANGELOG
+# - if any changes were made to README.md, mirror them in src/lib.rs docs
 version = "1.1.1"
 authors = [
     "Isis Lovecruft <isis@patternsinthevoid.net>",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2018"
 # - update CHANGELOG
 version = "1.1.0"
 authors = [
-    "Isis Lovecruft <isis@patternsinthevoid.net>", 
+    "Isis Lovecruft <isis@patternsinthevoid.net>",
     "DebugSteven <debugsteven@gmail.com>",
     "Henry de Valence <hdevalence@hdevalence.ca>",
 ]
@@ -55,3 +55,5 @@ std = ["curve25519-dalek/std"]
 nightly = ["curve25519-dalek/nightly"]
 u64_backend = ["curve25519-dalek/u64_backend"]
 u32_backend = ["curve25519-dalek/u32_backend"]
+fiat_u64_backend = ["curve25519-dalek/fiat_u64_backend"]
+fiat_u32_backend = ["curve25519-dalek/fiat_u32_backend"]

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ To install, add the following to your project's `Cargo.toml`:
 
 ```toml
 [dependencies]
-x25519-dalek = "2.0"
+x25519-dalek = "2.0.0-pre.2"
 ```
 
 # MSRV

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ To install, add the following to your project's `Cargo.toml`:
 
 ```toml
 [dependencies]
-x25519-dalek = "1.1"
+x25519-dalek = "1"
 ```
 
 # MSRV

--- a/README.md
+++ b/README.md
@@ -105,6 +105,10 @@ To install, add the following to your project's `Cargo.toml`:
 x25519-dalek = "1.1"
 ```
 
+# MSRV
+
+Current MSRV is 1.41 for production builds, and 1.48 for running tests.
+
 # Documentation
 
 Documentation is available [here](https://docs.rs/x25519-dalek).

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -124,7 +124,7 @@
 //!
 //! ```toml
 //! [dependencies]
-//! x25519-dalek = "2.0"
+//! x25519-dalek = "2.0.0-pre.2"
 //! ```
 //!
 //! # MSRV

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,9 +16,8 @@
 
 #![no_std]
 #![cfg_attr(feature = "bench", feature(test))]
-#![cfg_attr(feature = "nightly", feature(external_doc))]
 #![cfg_attr(feature = "nightly", deny(missing_docs))]
-#![cfg_attr(feature = "nightly", doc(include = "../README.md"))]
+#![cfg_attr(feature = "nightly", doc = include_str!("../README.md"))]
 #![doc(html_logo_url = "https://doc.dalek.rs/assets/dalek-logo-clear.png")]
 #![doc(html_root_url = "https://docs.rs/x25519-dalek/1.1.1")]
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,12 +17,139 @@
 #![no_std]
 #![cfg_attr(feature = "bench", feature(test))]
 #![cfg_attr(feature = "nightly", deny(missing_docs))]
-#![cfg_attr(feature = "nightly", doc = include_str!("../README.md"))]
 #![doc(html_logo_url = "https://doc.dalek.rs/assets/dalek-logo-clear.png")]
 #![doc(html_root_url = "https://docs.rs/x25519-dalek/1.1.1")]
 
-//! Note that docs will only build on nightly Rust until
-//! `feature(external_doc)` is stabilized.
+//! # x25519-dalek  [![](https://img.shields.io/crates/v/x25519-dalek.svg)](https://crates.io/crates/x25519-dalek) [![](https://docs.rs/x25519-dalek/badge.svg)](https://docs.rs/x25519-dalek) [![](https://travis-ci.org/dalek-cryptography/x25519-dalek.svg?branch=master)](https://travis-ci.org/dalek-cryptography/x25519-dalek)
+//!
+//! A pure-Rust implementation of x25519 elliptic curve Diffie-Hellman key exchange,
+//! with curve operations provided by
+//! [curve25519-dalek](https://github.com/dalek-cryptography/curve25519-dalek).
+//!
+//! This crate provides two levels of API: a bare byte-oriented `x25519`
+//! function which matches the function specified in [RFC7748][rfc7748], as
+//! well as a higher-level Rust API for static and ephemeral Diffie-Hellman.
+//!
+//! ## Examples
+//!
+//! <a href="https://shop.bubblesort.io">
+//! <img
+//!   style="float: right; width: auto; height: 300px;"
+//!   src="https://raw.githubusercontent.com/dalek-cryptography/x25519-dalek/master/res/bubblesort-zines-secret-messages-cover.jpeg"/>
+//! </a>
+//!
+//! Alice and Bob are two adorable kittens who have lost their mittens, and they
+//! wish to be able to send secret messages to each other to coordinate finding
+//! them, otherwise—if their caretaker cat finds out—they will surely be called
+//! naughty kittens and be given no pie!
+//!
+//! But the two kittens are quite clever.  Even though their paws are still too big
+//! and the rest of them is 90% fuzziness, these clever kittens have been studying
+//! up on modern public key cryptography and have learned a nifty trick called
+//! *elliptic curve Diffie-Hellman key exchange*.  With the right incantations, the
+//! kittens will be able to secretly organise to find their mittens, and then spend
+//! the rest of the afternoon nomming some yummy pie!
+//!
+//! First, Alice uses `EphemeralSecret::new()` and then
+//! `PublicKey::from()` to produce her secret and public keys:
+//!
+//! ```rust
+//! use rand_core::OsRng;
+//! use x25519_dalek::{EphemeralSecret, PublicKey};
+//!
+//! let alice_secret = EphemeralSecret::new(OsRng);
+//! let alice_public = PublicKey::from(&alice_secret);
+//! ```
+//!
+//! Bob does the same:
+//!
+//! ```rust
+//! # use rand_core::OsRng;
+//! # use x25519_dalek::{EphemeralSecret, PublicKey};
+//! let bob_secret = EphemeralSecret::new(OsRng);
+//! let bob_public = PublicKey::from(&bob_secret);
+//! ```
+//!
+//! Alice meows across the room, telling `alice_public` to Bob, and Bob
+//! loudly meows `bob_public` back to Alice.  Alice now computes her
+//! shared secret with Bob by doing:
+//!
+//! ```rust
+//! # use rand_core::OsRng;
+//! # use x25519_dalek::{EphemeralSecret, PublicKey};
+//! # let alice_secret = EphemeralSecret::new(OsRng);
+//! # let alice_public = PublicKey::from(&alice_secret);
+//! # let bob_secret = EphemeralSecret::new(OsRng);
+//! # let bob_public = PublicKey::from(&bob_secret);
+//! let alice_shared_secret = alice_secret.diffie_hellman(&bob_public);
+//! ```
+//!
+//! Similarly, Bob computes a shared secret by doing:
+//!
+//! ```rust
+//! # use rand_core::OsRng;
+//! # use x25519_dalek::{EphemeralSecret, PublicKey};
+//! # let alice_secret = EphemeralSecret::new(OsRng);
+//! # let alice_public = PublicKey::from(&alice_secret);
+//! # let bob_secret = EphemeralSecret::new(OsRng);
+//! # let bob_public = PublicKey::from(&bob_secret);
+//! let bob_shared_secret = bob_secret.diffie_hellman(&alice_public);
+//! ```
+//!
+//! These secrets are the same:
+//!
+//! ```rust
+//! # use rand_core::OsRng;
+//! # use x25519_dalek::{EphemeralSecret, PublicKey};
+//! # let alice_secret = EphemeralSecret::new(OsRng);
+//! # let alice_public = PublicKey::from(&alice_secret);
+//! # let bob_secret = EphemeralSecret::new(OsRng);
+//! # let bob_public = PublicKey::from(&bob_secret);
+//! # let alice_shared_secret = alice_secret.diffie_hellman(&bob_public);
+//! # let bob_shared_secret = bob_secret.diffie_hellman(&alice_public);
+//! assert_eq!(alice_shared_secret.as_bytes(), bob_shared_secret.as_bytes());
+//! ```
+//!
+//! Voilà!  Alice and Bob can now use their shared secret to encrypt their
+//! meows, for example, by using it to generate a key and nonce for an
+//! authenticated-encryption cipher.
+//!
+//! This example used the ephemeral DH API, which ensures that secret keys
+//! cannot be reused; Alice and Bob could instead use the static DH API
+//! and load a long-term secret key.
+//!
+//! # Installation
+//!
+//! To install, add the following to your project's `Cargo.toml`:
+//!
+//! ```toml
+//! [dependencies]
+//! x25519-dalek = "1.1"
+//! ```
+//!
+//! # Documentation
+//!
+//! Documentation is available [here](https://docs.rs/x25519-dalek).
+//!
+//! # Note
+//!
+//! This code matches the [RFC7748][rfc7748] test vectors.
+//! The elliptic curve
+//! operations are provided by `curve25519-dalek`, which makes a best-effort
+//! attempt to prevent software side-channels.
+//!
+//! "Secret Messages" cover image and [zine](https://shop.bubblesort.io/products/secret-messages-zine)
+//! copyright © Amy Wibowo ([@sailorhg](https://twitter.com/sailorhg))
+//!
+//! [rfc7748]: https://tools.ietf.org/html/rfc7748
+//!
+//! # See also
+//!
+//! - [crypto_box]: pure Rust public-key authenticated encryption compatible with
+//!   the NaCl family of encryption libraries (libsodium, TweetNaCl) which uses
+//!   `x25519-dalek` for key agreement
+//!
+//! [crypto_box]: https://github.com/RustCrypto/AEADs/tree/master/crypto_box
 
 extern crate curve25519_dalek;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,7 +18,7 @@
 #![cfg_attr(feature = "bench", feature(test))]
 #![cfg_attr(feature = "nightly", deny(missing_docs))]
 #![doc(html_logo_url = "https://doc.dalek.rs/assets/dalek-logo-clear.png")]
-#![doc(html_root_url = "https://docs.rs/x25519-dalek/1.1.1")]
+#![doc(html_root_url = "https://docs.rs/x25519-dalek/1.2.0")]
 
 //! # x25519-dalek  [![](https://img.shields.io/crates/v/x25519-dalek.svg)](https://crates.io/crates/x25519-dalek) [![](https://docs.rs/x25519-dalek/badge.svg)](https://docs.rs/x25519-dalek) [![](https://travis-ci.org/dalek-cryptography/x25519-dalek.svg?branch=master)](https://travis-ci.org/dalek-cryptography/x25519-dalek)
 //!
@@ -124,7 +124,7 @@
 //!
 //! ```toml
 //! [dependencies]
-//! x25519-dalek = "1.1"
+//! x25519-dalek = "1"
 //! ```
 //!
 //! # MSRV

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -127,6 +127,10 @@
 //! x25519-dalek = "1.1"
 //! ```
 //!
+//! # MSRV
+//!
+//! Current MSRV is 1.41 for production builds, and 1.48 for running tests.
+//!
 //! # Documentation
 //!
 //! Documentation is available [here](https://docs.rs/x25519-dalek).

--- a/src/x25519.rs
+++ b/src/x25519.rs
@@ -102,6 +102,10 @@ impl<'a> From<&'a EphemeralSecret> for PublicKey {
 /// Diffie-Hellman operation multiple times throughout the protocol, while the
 /// protocol run at a higher level is only conducted once per key.
 ///
+/// Similarly to [`EphemeralSecret`], this type does _not_ have serialisation
+/// methods, in order to discourage long-term usage of secret key material. (For
+/// long-term secret keys, see [`StaticSecret`].)
+///
 /// # Warning
 ///
 /// If you're uncertain about whether you should use this, then you likely
@@ -146,15 +150,6 @@ impl<'a> From<&'a ReusableSecret> for PublicKey {
 /// [`StaticSecret::diffie_hellman`] method does not consume the secret key, and the type provides
 /// serialization methods to save and load key material.  This means that the secret may be used
 /// multiple times (but does not *have to be*).
-///
-/// Some protocols, such as Noise, already handle the static/ephemeral distinction, so the
-/// additional guarantees provided by [`EphemeralSecret`] are not helpful or would cause duplicate
-/// code paths.  In this case, it may be useful to
-/// ```rust,ignore
-/// use x25519_dalek::StaticSecret as SecretKey;
-/// ```
-/// since the only difference between the two is that [`StaticSecret`] does not enforce at
-/// compile-time that the key is only used once.
 ///
 /// # Warning
 ///

--- a/src/x25519.rs
+++ b/src/x25519.rs
@@ -107,11 +107,13 @@ impl<'a> From<&'a EphemeralSecret> for PublicKey {
 /// [`EphemeralSecret`] at all times, as that type enforces at compile-time that
 /// secret keys are never reused, which can have very serious security
 /// implications for many protocols.
+#[cfg(feature = "reusable_secrets")]
 #[derive(Zeroize)]
 #[zeroize(drop)]
-pub struct NonSerializeableSecret(pub(crate) Scalar);
+pub struct ReusableSecret(pub(crate) Scalar);
 
-impl NonSerializeableSecret {
+#[cfg(feature = "reusable_secrets")]
+impl ReusableSecret {
     /// Perform a Diffie-Hellman key agreement between `self` and
     /// `their_public` key to produce a [`SharedSecret`].
     pub fn diffie_hellman(&self, their_public: &PublicKey) -> SharedSecret {
@@ -124,13 +126,14 @@ impl NonSerializeableSecret {
 
         csprng.fill_bytes(&mut bytes);
 
-        NonSerializeableSecret(clamp_scalar(bytes))
+        ReusableSecret(clamp_scalar(bytes))
     }
 }
 
-impl<'a> From<&'a NonSerializeableSecret> for PublicKey {
-    /// Given an x25519 [`NonSerializeableSecret`] key, compute its corresponding [`PublicKey`].
-    fn from(secret: &'a NonSerializeableSecret) -> PublicKey {
+#[cfg(feature = "reusable_secrets")]
+impl<'a> From<&'a ReusableSecret> for PublicKey {
+    /// Given an x25519 [`ReusableSecret`] key, compute its corresponding [`PublicKey`].
+    fn from(secret: &'a ReusableSecret) -> PublicKey {
         PublicKey((&ED25519_BASEPOINT_TABLE * &secret.0).to_montgomery())
     }
 }

--- a/src/x25519.rs
+++ b/src/x25519.rs
@@ -102,6 +102,8 @@ impl<'a> From<&'a EphemeralSecret> for PublicKey {
 /// Diffie-Hellman operation multiple times throughout the protocol, while the
 /// protocol run at a higher level is only conducted once per key.
 ///
+/// # Warning
+///
 /// If you're uncertain about whether you should use this, then you likely
 /// should not be using this.  Our strongly recommended advice is to use
 /// [`EphemeralSecret`] at all times, as that type enforces at compile-time that
@@ -153,6 +155,14 @@ impl<'a> From<&'a ReusableSecret> for PublicKey {
 /// ```
 /// since the only difference between the two is that [`StaticSecret`] does not enforce at
 /// compile-time that the key is only used once.
+///
+/// # Warning
+///
+/// If you're uncertain about whether you should use this, then you likely
+/// should not be using this.  Our strongly recommended advice is to use
+/// [`EphemeralSecret`] at all times, as that type enforces at compile-time that
+/// secret keys are never reused, which can have very serious security
+/// implications for many protocols.
 #[cfg_attr(feature = "serde", serde(crate = "our_serde"))]
 #[cfg_attr(
     feature = "serde",

--- a/src/x25519.rs
+++ b/src/x25519.rs
@@ -126,7 +126,7 @@ impl ReusableSecret {
         SharedSecret(&self.0 * their_public.0)
     }
 
-    /// Generate a non-serializeable x25519 key.
+    /// Generate a non-serializeable x25519 [`ReuseableSecret`] key.
     pub fn new<T: RngCore + CryptoRng>(mut csprng: T) -> Self {
         let mut bytes = [0u8; 32];
 

--- a/src/x25519.rs
+++ b/src/x25519.rs
@@ -212,6 +212,7 @@ impl SharedSecret {
     /// [relevant]: https://tools.ietf.org/html/rfc7748#page-15
     /// [public]: https://vnhacker.blogspot.com/2015/09/why-not-validating-curve25519-public.html
     /// [discussions]: https://vnhacker.blogspot.com/2016/08/the-internet-of-broken-protocols.html
+    #[must_use]
     pub fn was_contributory(&self) -> bool {
         !self.0.is_identity()
     }

--- a/src/x25519.rs
+++ b/src/x25519.rs
@@ -110,7 +110,7 @@ impl<'a> From<&'a EphemeralSecret> for PublicKey {
 /// secret keys are never reused, which can have very serious security
 /// implications for many protocols.
 #[cfg(feature = "reusable_secrets")]
-#[derive(Zeroize)]
+#[derive(Clone, Zeroize)]
 #[zeroize(drop)]
 pub struct ReusableSecret(pub(crate) Scalar);
 

--- a/tests/x25519_tests.rs
+++ b/tests/x25519_tests.rs
@@ -59,8 +59,7 @@ fn serde_bincode_public_key_matches_from_bytes() {
 fn serde_bincode_static_secret_roundtrip() {
     use bincode;
 
-    let static_secret = StaticSecret(clamp_scalar([0x24; 32]));
-
+    let static_secret = StaticSecret::from([0x24; 32]);
     let encoded = bincode::serialize(&static_secret).unwrap();
     let decoded: StaticSecret = bincode::deserialize(&encoded).unwrap();
 
@@ -73,7 +72,7 @@ fn serde_bincode_static_secret_roundtrip() {
 fn serde_bincode_static_secret_matches_from_bytes() {
     use bincode;
 
-    let expected = StaticSecret(clamp_scalar([0x24; 32]));
+    let expected = StaticSecret::from([0x24; 32]);
     let clamped_bytes = clamp_scalar([0x24; 32]).to_bytes();
     let decoded: StaticSecret = bincode::deserialize(&clamped_bytes).unwrap();
 

--- a/tests/x25519_tests.rs
+++ b/tests/x25519_tests.rs
@@ -1,5 +1,16 @@
 
+use curve25519_dalek::constants::ED25519_BASEPOINT_TABLE;
+use curve25519_dalek::scalar::Scalar;
+
 use x25519_dalek::*;
+
+fn clamp_scalar(mut scalar: [u8; 32]) -> Scalar {
+    scalar[0] &= 248;
+    scalar[31] &= 127;
+    scalar[31] |= 64;
+
+    Scalar::from_bits(scalar)
+}
 
 #[test]
 fn byte_basepoint_matches_edwards_scalar_mul() {


### PR DESCRIPTION
* Update `curve25519-dalek` dependency to include https://github.com/mobilecoinfoundation/curve25519-dalek/pull/2
* Merge changes from https://github.com/dalek-cryptography/x25519-dalek/tree/develop


Supports https://github.com/mobilecoinfoundation/mobilecoin/issues/1326