### PR TITLE
Run CI on mobilecoin branch and bump MSRV to 1.51

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -71,14 +71,14 @@ jobs:
         args: --features "serde"
 
   msrv:
-    name: Current MSRV is 1.41
+    name: Current MSRV is 1.51
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
     - uses: actions-rs/toolchain@v1
       with:
         profile: minimal
-        toolchain: 1.41
+        toolchain: 1.51
         override: true
     - uses: actions-rs/cargo@v1
       with:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [ '*' ]
   pull_request:
-    branches: [ main, develop, release ]
+    branches: [ main, develop, release, mobilecoin ]
 
 env:
   CARGO_TERM_COLOR: always

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ Entries are listed in reverse chronological order.
 * Pin `zeroize` to version 1.3 to support a wider range of MSRVs.
 * Add CI via Github actions.
 * Fix breakage in the serde unittests.
-* MSRV is now 1.41 for production and 1.48 for development.
+* MSRV is now 1.51 for production and 1.51 for development.
 * Add an optional check to `SharedSecret` for contibutory behaviour.
 * Add implementation of `ReusableSecret` keys which are non-ephemeral, but which
   cannot be serialised to discourage long-term use.

--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ x25519-dalek = "2.0.0-pre.2"
 
 # MSRV
 
-Current MSRV is 1.41 for production builds, and 1.48 for running tests.
+Current MSRV is 1.51 for production builds, and 1.51 for running tests.
 
 # Documentation
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -129,7 +129,7 @@
 //!
 //! # MSRV
 //!
-//! Current MSRV is 1.41 for production builds, and 1.48 for running tests.
+//! Current MSRV is 1.51 for production builds, and 1.51 for running tests.
 //!
 //! # Documentation
 //!


### PR DESCRIPTION
To fix CI failures. We can afford to bump MSRV for our fork.